### PR TITLE
Improve logs

### DIFF
--- a/whisper_streaming/whisper_online_main.py
+++ b/whisper_streaming/whisper_online_main.py
@@ -155,14 +155,12 @@ def main_simulation_from_file(factory, add_args=None):
         #    - beg and end timestamp of the text segment, as estimated by Whisper model. The timestamps are not accurate, but they're useful anyway
         # - the next words: segment transcript
         if now is None:
-            now = time.time()-start
-        if o[0] is not None:
-            print("%1.4f %1.0f %1.0f %s" % (now*1000, o[0]*1000,o[1]*1000,o[2]),file=logfile,flush=True)
-            print("%1.4f %1.0f %1.0f %s" % (now*1000, o[0]*1000,o[1]*1000,o[2]),flush=True)
-        else:
-            # No text, so no output
-            pass
+            now = time.time() - start
 
+        start_ts, end_ts, text = o
+        if start_ts is not None and end_ts is not None:
+            logger.info(f"{now * 1000:.4f} {start_ts * 1000:.0f} {end_ts * 1000:.0f} {text}")
+            
     if args.offline: ## offline mode processing (for testing/debugging)
         a = load_audio(audio_path)
         online.insert_audio_chunk(a)
@@ -225,5 +223,4 @@ def main_simulation_from_file(factory, add_args=None):
         now = None
 
     o = online.finish()
-    print("tady",o,file=sys.stderr)
     output_transcript(o, now=now)

--- a/whisper_streaming/whisper_online_main.py
+++ b/whisper_streaming/whisper_online_main.py
@@ -160,6 +160,7 @@ def main_simulation_from_file(factory, add_args=None):
         start_ts, end_ts, text = o
         if start_ts is not None and end_ts is not None:
             logger.info(f"{now * 1000:.4f} {start_ts * 1000:.0f} {end_ts * 1000:.0f} {text}")
+            print(f"{now * 1000:.4f} {start_ts * 1000:.0f} {end_ts * 1000:.0f} {text}", flush=True)
             
     if args.offline: ## offline mode processing (for testing/debugging)
         a = load_audio(audio_path)


### PR DESCRIPTION
Associated to https://github.com/ufal/SimulStreaming/issues/1 

Replace most print statements with logger to reduce console noise and improve traceability, exemple:

```
(3.12.8) SimulStreaming % python3 simulstreaming_whisper.py audio.wav --language en --task transcribe --model_path ./tiny.pt --log-level INFO 
INFO    Audio duration is: 11.00 seconds
INFO    2591.8002 0 2410  And so my fellow Americans
INFO    4995.8279 2410 4820 , ask
INFO    6176.7800 4820 6025  not
INFO    7419.1980 6025 7230  what your country
INFO    8630.8880 7230 8435  can do for you
INFO    9853.2591 8435 9640 , ask what
INFO    11066.4122 9640 10845  you can do for your country
```


## 📄 Contributor License Agreement Consent

*The authors of SimulStreaming wish to enhance ways to collect and use feedback from users of SimulStreaming in future research and development while not limiting community contributions and non-commercial use. Therefore, this project is dual-licenced; the commercial use requires registration before obtaining a commercial licence.*

*Before we merge this pull request, we kindly ask you to consider granting the permissions below. If you have questions or prefer a different arrangement, feel free to leave a comment or contact the author. Thank you!*

By checking the boxes below, you confirm the following:

- [x] I confirm that I have the legal right to grant a license for the contributions in this pull request to the maintainers of the SimulStreaming project.
*(For example, you are the only author, of legal age, not restricted by employment or institutional agreements.)*

- [x] I grant the maintainers of SimulStreaming permission to re-license my contribution under any license, including commercial ones.