### PR TITLE
fixed word-level timestamps

### DIFF
--- a/simul_whisper/generation_progress.py
+++ b/simul_whisper/generation_progress.py
@@ -1,0 +1,40 @@
+class Tokens:
+    def __init__(self, tokens):
+        self.tokens = tokens
+
+#    def clone(self):
+#        return Tokens(self.tokens.clone())
+
+    def __str__(self):
+        return str(self.tokens.tolist())
+
+    def __repr__(self):
+        return self.__str__()
+
+class BeamTokens(Tokens):
+    def __init__(self, tokens, beam_size):
+        self.tokens = tokens
+        self.beam_size = beam_size
+
+    def clone(self):
+        return BeamTokens(self.tokens.clone())
+
+    def __str__(self):
+        return f"BeamTokens({self.tokens.tolist()}, beam_size={self.beam_size})"
+
+    def __repr__(self):
+        return self.__str__()
+
+class Logits(Tokens):
+    def __init__(self, logits):
+        super().__init__(logits)
+
+#    def clone(self):
+#        return Logits(self.tokens.clone(), self.beam_size)
+
+    def __str__(self):
+#        return "abc"
+        return f"Logits({self.tokens.shape})"
+
+    def __repr__(self):
+        return self.__str__()

--- a/simul_whisper/simul_whisper.py
+++ b/simul_whisper/simul_whisper.py
@@ -306,7 +306,7 @@ class PaddedAlignAttWhisper:
         logger.info("Decoding loop starts\n")
 
         attn_of_alignment_heads = None
-        most_attended_frame = None
+        miost_attended_frame = None
 
         token_len_before_decoding = current_tokens.shape[1]
         
@@ -455,13 +455,13 @@ class PaddedAlignAttWhisper:
                     self.tokenizer.decode([current_tokens[i, -1].item()])
                 ))
 
-        for k,v in generation.items():
-            print(k,v,file=sys.stderr)
-        for x in generation_progress:
-            for y in x.items():
-                print("\t\t",*y,file=sys.stderr)
-            print("\t","----", file=sys.stderr)
-        print("\t", "end of generation_progress_loop", file=sys.stderr)
+#        for k,v in generation.items():
+#            print(k,v,file=sys.stderr)
+#        for x in generation_progress:
+#            for y in x.items():
+#                print("\t\t",*y,file=sys.stderr)
+#            print("\t","----", file=sys.stderr)
+#        print("\t", "end of generation_progress_loop", file=sys.stderr)
         #    sys.exit(1)
         ####################### End of decoding loop
 

--- a/simul_whisper/simul_whisper.py
+++ b/simul_whisper/simul_whisper.py
@@ -490,7 +490,8 @@ class PaddedAlignAttWhisper:
         else:
             # going to truncate the tokens after the last space
             split_words, split_tokens = self.tokenizer.split_to_word_tokens(tokens_to_split.tolist())
-            generation["result"] = {"split_words": split_words, "split_tokens": split_tokens}
+            generation["result"] = {"split_words": split_words[:-1], "split_tokens": split_tokens[:-1]}
+            generation["result_truncated"] = {"split_words": split_words[-1:], "split_tokens": split_tokens[-1:]}
 
 #            text_to_split = self.tokenizer.decode(tokens_to_split)
 #            logger.debug(f"text_to_split: {text_to_split}")

--- a/simulstreaming_whisper.py
+++ b/simulstreaming_whisper.py
@@ -157,10 +157,10 @@ class SimulWhisperOnline(OnlineProcessorInterface):
 #        print((len(self.model.segments)+1) * self.model.cfg.segment_length, self.model.cfg.buffer_len)
 
 #        n = self.model.infer(audio,"",force_decode="",is_last=self.is_last)
-        n = self.model.infer(audio,is_last=self.is_last)
+        n, _ = self.model.infer(audio,is_last=self.is_last)
 
         #print("tady",n,file=sys.stderr)
-        n = n[n<DEC_PAD]
+        #n = n[n<DEC_PAD]
         #print("OUTPUT <DEC_PAD",n,file=sys.stderr)
 #        result = n
         result = self.model.tokenizer.decode(n)

--- a/simulstreaming_whisper.py
+++ b/simulstreaming_whisper.py
@@ -128,7 +128,6 @@ class SimulWhisperASR(ASRBase):
 
 
 class SimulWhisperOnline(OnlineProcessorInterface):
-    chunks = 1
 
     def __init__(self, asr):
         self.model = asr.model
@@ -147,14 +146,8 @@ class SimulWhisperOnline(OnlineProcessorInterface):
 
         self.audio_bufer_offset = self.offset
 
-        if self.file is not None:
-            self.file.close()
-        self.file = open(f"chunk-{self.chunks}-{self.offset}.wav", "wb")
-        self.chunks += 1
-
     def insert_audio_chunk(self, audio):
         self.audio_chunks.append(torch.from_numpy(audio))
-        self.file.write(audio)
 
     def timestamped_text(self, tokens, generation):
 
@@ -220,7 +213,6 @@ class SimulWhisperOnline(OnlineProcessorInterface):
         o = self.process_iter()
         self.is_last = False
         self.model.refresh_segment(complete=True)
-        self.file.close()
         return o
     
 

--- a/simulstreaming_whisper.py
+++ b/simulstreaming_whisper.py
@@ -145,6 +145,7 @@ class SimulWhisperOnline(OnlineProcessorInterface):
         self.end = self.offset
 
         self.audio_bufer_offset = self.offset
+        self.last_ts = (-1,-1)
 
     def insert_audio_chunk(self, audio):
         self.audio_chunks.append(torch.from_numpy(audio))
@@ -196,12 +197,15 @@ class SimulWhisperOnline(OnlineProcessorInterface):
 
         if len(text) == 0:
             return (None,None,"")
-        self.beg = ts_words[0][0]+self.audio_bufer_offset
+        self.beg = ts_words[0][0]+self.audio_bufer_offset  # it should be this
+        self.beg = max(self.beg, self.last_ts[0]+1)  # but let's create the timestamps non-decreasing -- at least last beg + 1 
         if self.is_last:
             e = self.end
         else:
             e = ts_words[-1][1]+self.audio_bufer_offset
+        e = max(e, self.last_ts[1]+1)
 
+        self.last_ts = (self.beg, e)
 #        self.beg = e
         
         return (self.beg,e,text)

--- a/token_buffer.py
+++ b/token_buffer.py
@@ -54,8 +54,8 @@ class TokenBuffer:
 
         ids = tokenizer.encode(self.text[after:])
         words, wids = self.tokenizer.split_to_word_tokens(ids)
-        print(words, file=sys.stderr)
-        print(wids, file=sys.stderr)
+#        print(words, file=sys.stderr)
+#        print(wids, file=sys.stderr)
         if not words:
             return 0
         self.text = self.text[:after] + "".join(words[num:])

--- a/whisper_streaming/vac_online_processor.py
+++ b/whisper_streaming/vac_online_processor.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import logging
 logger = logging.getLogger(__name__)
+import sys
 
 class VACOnlineASRProcessor(OnlineProcessorInterface):
     '''Wraps OnlineASRProcessor with VAC (Voice Activity Controller). 
@@ -40,20 +41,21 @@ class VACOnlineASRProcessor(OnlineProcessorInterface):
         self.buffer_offset = 0  # in frames
 
     def clear_buffer(self):
-        self.buffer_offset += len(self.audio_buffer)
+        #self.buffer_offset += len(self.audio_buffer)
         self.audio_buffer = np.array([],dtype=np.float32)
 
 
     def insert_audio_chunk(self, audio):
         res = self.vac(audio)
         self.audio_buffer = np.append(self.audio_buffer, audio)
-
         if res is not None:
-            frame = list(res.values())[0]-self.buffer_offset
+            frame = list(res.values())[0]
+            print(res,file=sys.stderr)
+            print("FRAME", frame, "FRAMW/16000",frame/16000, "buffer_offset", self.buffer_offset, file=sys.stderr)
             if 'start' in res and 'end' not in res:
                 self.status = 'voice'
                 send_audio = self.audio_buffer[frame:]
-                self.online.init(offset=(frame+self.buffer_offset)/self.SAMPLING_RATE)
+                self.online.init(offset=frame/self.SAMPLING_RATE)
                 self.online.insert_audio_chunk(send_audio)
                 self.current_online_chunk_buffer_size += len(send_audio)
                 self.clear_buffer()
@@ -69,10 +71,11 @@ class VACOnlineASRProcessor(OnlineProcessorInterface):
                 end = res["end"]-self.buffer_offset
                 self.status = 'nonvoice'
                 send_audio = self.audio_buffer[beg:end]
-                self.online.init(offset=(beg+self.buffer_offset)/self.SAMPLING_RATE)
+                self.online.init(offset=(res["start"]/self.SAMPLING_RATE))
                 self.online.insert_audio_chunk(send_audio)
                 self.current_online_chunk_buffer_size += len(send_audio)
                 self.is_currently_final = True
+                #self.buffer_offset += len(self.audio_buffer)-res["start"] + len(self.audio_buffer)-res["end"]
                 self.clear_buffer()
         else:
             if self.status == 'voice':
@@ -80,6 +83,7 @@ class VACOnlineASRProcessor(OnlineProcessorInterface):
                 self.current_online_chunk_buffer_size += len(self.audio_buffer)
                 self.clear_buffer()
             else:
+                print("nonvoice", len(self.audio_buffer), self.buffer_offset, file=sys.stderr)
                 # We keep 1 second because VAD may later find start of voice in it.
                 # But we trim it to prevent OOM. 
                 self.buffer_offset += max(0,len(self.audio_buffer)-self.SAMPLING_RATE)

--- a/whisper_streaming/whisper_online_main.py
+++ b/whisper_streaming/whisper_online_main.py
@@ -71,6 +71,9 @@ def asr_factory(args, factory=None):
         online = VACOnlineASRProcessor(args.min_chunk_size, online)
 
     if args.task == "translate":
+        if args.model_path.endswith(".en.pt"):
+            logger.error(f"The model {args.model_path} is English only. Translation is not available. Terminating.")
+            sys.exit(1)
         asr.set_translate_task()
 
     return asr, online


### PR DESCRIPTION
- #4 
- dict generation passes documentable information from decoding loop
- timestamps inferred very approximately, via most attended frame. DTW could be applied
- timstamps increasing (approximated), to be compatible to https://github.com/ELITR/online-text-flow . 
- online-text-flow made compatible with SimulStreaming format -- splitted words to multiple lines of output






## 📄 Contributor License Agreement Consent

*The authors of SimulStreaming wish to enhance ways to collect and use feedback from users of SimulStreaming in future research and development while not limiting community contributions and non-commercial use. Therefore, this project is dual-licenced; the commercial use requires registration before obtaining a commercial licence.*

*Before we merge this pull request, we kindly ask you to consider granting the permissions below. If you have questions or prefer a different arrangement, feel free to leave a comment or contact the author. Thank you!*

By checking the boxes below, you confirm the following:

- [x ] I confirm that I have the legal right to grant a license for the contributions in this pull request to the maintainers of the SimulStreaming project.
*(For example, you are the only author, of legal age, not restricted by employment or institutional agreements.)*

- [x ] I grant the maintainers of SimulStreaming permission to re-license my contribution under any license, including commercial ones.
