### PR TITLE
remove obsolete --vad parameter from the argparser and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Follow [translate/README.txt](translate/README.txt).
 
 
 ```
-usage: simulstreaming_whisper.py [-h] [--min-chunk-size MIN_CHUNK_SIZE] [--lan LAN] [--task {transcribe,translate}] [--vac] [--vac-chunk-size VAC_CHUNK_SIZE] [--vad]
+usage: simulstreaming_whisper.py [-h] [--min-chunk-size MIN_CHUNK_SIZE] [--lan LAN] [--task {transcribe,translate}] [--vac] [--vac-chunk-size VAC_CHUNK_SIZE]
                                  [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--model_path MODEL_PATH] [--beams BEAMS] [--decoder DECODER] [--audio_max_len AUDIO_MAX_LEN]
                                  [--audio_min_len AUDIO_MIN_LEN] [--frame_threshold FRAME_THRESHOLD] [--cif_ckpt_path CIF_CKPT_PATH] [--never_fire | --no-never_fire]
                                  [--init_prompt INIT_PROMPT] [--static_init_prompt STATIC_INIT_PROMPT] [--max_context_tokens MAX_CONTEXT_TOKENS] [--start_at START_AT] [--comp_unaware]
@@ -69,7 +69,6 @@ WhisperStreaming processor arguments (shared for simulation from file and for th
   --vac                 Use VAC = voice activity controller. Recommended. Requires torch.
   --vac-chunk-size VAC_CHUNK_SIZE
                         VAC sample size in seconds.
-  --vad                 Use VAD = voice activity detection, with the default parameters.
 
 Whisper arguments:
   --model_path MODEL_PATH

--- a/whisper_streaming/whisper_online_main.py
+++ b/whisper_streaming/whisper_online_main.py
@@ -45,8 +45,6 @@ def processor_args(parser):
                         help='Use VAC = voice activity controller. Recommended. Requires torch.')
     group.add_argument('--vac-chunk-size', type=float, default=0.04, 
                         help='VAC sample size in seconds.')
-    group.add_argument('--vad', action="store_true", default=False, 
-                        help='Use VAD = voice activity detection, with the default parameters.')
 
     parser.add_argument("-l", "--log-level", dest="log_level", 
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], 


### PR DESCRIPTION
The --vad option does not have any functionality as of now, as discussed in issue https://github.com/ufal/SimulStreaming/issues/8.

## 📄 Contributor License Agreement Consent

*The authors of SimulStreaming wish to enhance ways to collect and use feedback from users of SimulStreaming in future research and development while not limiting community contributions and non-commercial use. Therefore, this project is dual-licenced; the commercial use requires registration before obtaining a commercial licence.*

*Before we merge this pull request, we kindly ask you to consider granting the permissions below. If you have questions or prefer a different arrangement, feel free to leave a comment or contact the author. Thank you!*

By checking the boxes below, you confirm the following:

- [ x] I confirm that I have the legal right to grant a license for the contributions in this pull request to the maintainers of the SimulStreaming project.
*(For example, you are the only author, of legal age, not restricted by employment or institutional agreements.)*

- [ x] I grant the maintainers of SimulStreaming permission to re-license my contribution under any license, including commercial ones.
