### PR TITLE
Fix VAD index calculation logic

### DIFF
--- a/whisper_streaming/vac_online_processor.py
+++ b/whisper_streaming/vac_online_processor.py
@@ -7,17 +7,18 @@ logger = logging.getLogger(__name__)
 import sys
 
 class VACOnlineASRProcessor(OnlineProcessorInterface):
-    '''Wraps OnlineASRProcessor with VAC (Voice Activity Controller). 
+    '''Wraps OnlineASRProcessor with VAC (Voice Activity Controller).
 
-    It works the same way as OnlineASRProcessor: it receives chunks of audio (e.g. 0.04 seconds), 
-    it runs VAD and continuously detects whether there is speech or not. 
+    It works the same way as OnlineASRProcessor: it receives chunks of audio (e.g. 0.04 seconds),
+    it runs VAD and continuously detects whether there is speech or not.
     When it detects end of speech (non-voice for 500ms), it makes OnlineASRProcessor to end the utterance immediately.
     '''
 
-    def __init__(self, online_chunk_size, online):
+    def __init__(self, online_chunk_size, online, min_buffered_length=1):
         self.online_chunk_size = online_chunk_size
-
         self.online = online
+
+        self.min_buffered_frames = int(min_buffered_length * self.SAMPLING_RATE)
 
         # VAC:
         import torch
@@ -25,7 +26,7 @@ class VACOnlineASRProcessor(OnlineProcessorInterface):
             repo_or_dir='snakers4/silero-vad',
             model='silero_vad'
         )
-        self.vac = FixedVADIterator(model)  # we use the default options there: 500ms silence, 100ms padding, etc.  
+        self.vac = FixedVADIterator(model)  # we use the default options there: 500ms silence, 100ms padding, etc.
 
         self.init()
 
@@ -41,51 +42,56 @@ class VACOnlineASRProcessor(OnlineProcessorInterface):
         self.buffer_offset = 0  # in frames
 
     def clear_buffer(self):
-        #self.buffer_offset += len(self.audio_buffer)
         self.audio_buffer = np.array([],dtype=np.float32)
-
 
     def insert_audio_chunk(self, audio):
         res = self.vac(audio)
         self.audio_buffer = np.append(self.audio_buffer, audio)
         if res is not None:
-            frame = list(res.values())[0]
+            frame = list(res.values())[0] - self.buffer_offset
+            frame = max(0, frame)
             if 'start' in res and 'end' not in res:
                 self.status = 'voice'
                 send_audio = self.audio_buffer[frame:]
-                self.online.init(offset=frame/self.SAMPLING_RATE)
+                self.online.init(offset=(frame + self.buffer_offset)/self.SAMPLING_RATE)
                 self.online.insert_audio_chunk(send_audio)
                 self.current_online_chunk_buffer_size += len(send_audio)
+                self.buffer_offset += len(self.audio_buffer)
                 self.clear_buffer()
             elif 'end' in res and 'start' not in res:
                 self.status = 'nonvoice'
-                send_audio = self.audio_buffer[:frame]
-                self.online.insert_audio_chunk(send_audio)
-                self.current_online_chunk_buffer_size += len(send_audio)
+                if frame > 0:
+                    send_audio = self.audio_buffer[:frame]
+                    self.online.insert_audio_chunk(send_audio)
+                    self.current_online_chunk_buffer_size += len(send_audio)
                 self.is_currently_final = True
-                self.clear_buffer()
+                keep_frames = min(len(self.audio_buffer) - frame, self.min_buffered_frames)
+                self.buffer_offset += len(self.audio_buffer) - keep_frames
+                self.audio_buffer = self.audio_buffer[-keep_frames:]
             else:
-                beg = res["start"]-self.buffer_offset
-                end = res["end"]-self.buffer_offset
+                beg = max(0, res["start"] - self.buffer_offset)
+                end = max(0, res["end"] - self.buffer_offset)
                 self.status = 'nonvoice'
-                send_audio = self.audio_buffer[beg:end]
-                self.online.init(offset=(res["start"]/self.SAMPLING_RATE))
-                self.online.insert_audio_chunk(send_audio)
-                self.current_online_chunk_buffer_size += len(send_audio)
+                if beg < end:
+                    send_audio = self.audio_buffer[beg:end]
+                    self.online.init(offset=((beg + self.buffer_offset)/self.SAMPLING_RATE))
+                    self.online.insert_audio_chunk(send_audio)
+                    self.current_online_chunk_buffer_size += len(send_audio)
                 self.is_currently_final = True
-                #self.buffer_offset += len(self.audio_buffer)-res["start"] + len(self.audio_buffer)-res["end"]
-                self.clear_buffer()
+                keep_frames = min(len(self.audio_buffer) - end, self.min_buffered_frames)
+                self.buffer_offset += len(self.audio_buffer) - keep_frames
+                self.audio_buffer = self.audio_buffer[-keep_frames:]
         else:
             if self.status == 'voice':
                 self.online.insert_audio_chunk(self.audio_buffer)
                 self.current_online_chunk_buffer_size += len(self.audio_buffer)
+                self.buffer_offset += len(self.audio_buffer)
                 self.clear_buffer()
             else:
                 # We keep 1 second because VAD may later find start of voice in it.
-                # But we trim it to prevent OOM. 
-                self.buffer_offset += max(0,len(self.audio_buffer)-self.SAMPLING_RATE)
-                self.audio_buffer = self.audio_buffer[-self.SAMPLING_RATE:]
-
+                # But we trim it to prevent OOM.
+                self.buffer_offset += max(0, len(self.audio_buffer) - self.min_buffered_frames)
+                self.audio_buffer = self.audio_buffer[-self.min_buffered_frames:]
 
     def process_iter(self):
         if self.is_currently_final:


### PR DESCRIPTION
*Describe your contribution here:*

Fixed an issue with VAD indexing. Before the fix, the index used to split the audio buffer into "voice" and "non-voice" parts was calculated incorrectly and kept increasing over time. After some time, the index exceeded the buffer length, causing the first part of new VAD segments to be skipped when sending audio to the ASR model. This often caused the first words of an utterance not being transcribed.

## 📄 Contributor License Agreement Consent

*The authors of SimulStreaming wish to enhance ways to collect and use feedback from users of SimulStreaming in future research and development while not limiting community contributions and non-commercial use. Therefore, this project is dual-licenced; the commercial use requires registration before obtaining a commercial licence.*

*Before we merge this pull request, we kindly ask you to consider granting the permissions below. If you have questions or prefer a different arrangement, feel free to leave a comment or contact the author. Thank you!*

By checking the boxes below, you confirm the following:

- [x] I confirm that I have the legal right to grant a license for the contributions in this pull request to the maintainers of the SimulStreaming project.
*(For example, you are the only author, of legal age, not restricted by employment or institutional agreements.)*

- [X] I grant the maintainers of SimulStreaming permission to re-license my contribution under any license, including commercial ones.
