### PR TITLE
Update the median_kernel() function to use the Triton v3 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,5 @@ torch
 tqdm
 tiktoken
 
-# both Whisper and SimulWhisper. SimulWhisper requires <3
-triton>=2.0.0,<3;platform_machine=="x86_64" and sys_platform=="linux" or sys_platform=="linux2"
-
-
+# both Whisper and SimulWhisper. Updated to Triton v3
+triton>=3.0.0

--- a/simul_whisper/whisper/triton_ops.py
+++ b/simul_whisper/whisper/triton_ops.py
@@ -60,7 +60,8 @@ def median_kernel(filter_width: int):
         tl.store(y_ptr + offsets, MIDDLE_ROW_HERE, mask=mask)  # noqa: F821
 
     kernel = triton.JITFunction(kernel.fn)
-    kernel.src = kernel.src.replace(
+    src = kernel.src
+    src = src.replace(
         "    LOAD_ALL_ROWS_HERE",
         "\n".join(
             [
@@ -69,7 +70,7 @@ def median_kernel(filter_width: int):
             ]
         ),
     )
-    kernel.src = kernel.src.replace(
+    src = src.replace(
         "    BUBBLESORT_HERE",
         "\n\n".join(
             [
@@ -90,7 +91,10 @@ def median_kernel(filter_width: int):
             ]
         ),
     )
-    kernel.src = kernel.src.replace("MIDDLE_ROW_HERE", f"row{filter_width // 2}")
+    src = src.replace("MIDDLE_ROW_HERE", f"row{filter_width // 2}")
+
+    kernel._unsafe_update_src(src)
+    kernel.hash = None
 
     return kernel
 


### PR DESCRIPTION
Apparently kernel.src cannot be directly assigned in v3, so store src in a local copy and modify that one before applying the updates. This allows use with Python >3.11 and Debian trixie which does not package triton v2.

Tested on simulated streaming audio locally.

see https://github.com/openai/whisper/discussions/2597