### PR TITLE
Restore triton v2 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ torch
 tqdm
 tiktoken
 
-# both Whisper and SimulWhisper. Updated to Triton v3
-triton>=3.0.0
+# both Whisper and SimulWhisper. Now supports Triton 2.x and 3.x with compatibility fix
+triton>=2.0.0;platform_machine=="x86_64" and sys_platform=="linux" or sys_platform=="linux2"

--- a/simul_whisper/whisper/triton_ops.py
+++ b/simul_whisper/whisper/triton_ops.py
@@ -93,8 +93,11 @@ def median_kernel(filter_width: int):
     )
     src = src.replace("MIDDLE_ROW_HERE", f"row{filter_width // 2}")
 
-    kernel._unsafe_update_src(src)
-    kernel.hash = None
+    if hasattr(kernel, "_unsafe_update_src") is True:
+        kernel._unsafe_update_src(src)
+        kernel.hash = None
+    else:
+        kernel.src = src
 
     return kernel
 


### PR DESCRIPTION
This is a small addition to PR #22 since I have been changing this in parallel. In this variant, triton v2 is still working too, and Linux OS is correctly added again in requirements (whisper upstream has that too). If fine, please merge after #22 .
