### PR TITLE
Fix server crash on missing keys and bound token/context growth

### DIFF
--- a/simulstreaming/whisper/simul_whisper/simul_whisper.py
+++ b/simulstreaming/whisper/simul_whisper/simul_whisper.py
@@ -122,7 +122,7 @@ class PaddedAlignAttWhisper:
         self.last_attend_frame = -self.cfg.rewind_threshold
 
         if self.cfg.max_context_tokens is None:
-            self.max_context_tokens = self.max_text_len
+            self.max_context_tokens = self.max_text_len // 2
         else:
             self.max_context_tokens = self.cfg.max_context_tokens
         self.init_context()
@@ -282,6 +282,18 @@ class PaddedAlignAttWhisper:
             if len(self.tokens) > 1:
                 self.context.append_token_ids(self.tokens[1][0,:])
                 self.tokens = [self.initial_tokens] + self.tokens[2:]
+
+        # Prevent unbounded growth of self.tokens: fold old entries into
+        # context when the total token count exceeds half the max text length.
+        # This mirrors the per-segment trimming above but catches accumulation
+        # from repeated infer() calls on the same audio window.
+        total_tok_len = sum(t.shape[1] for t in self.tokens)
+        while total_tok_len > self.max_text_len // 2 and len(self.tokens) > 1:
+            self.context.append_token_ids(self.tokens[1][0,:])
+            total_tok_len -= self.tokens[1].shape[1]
+            self.tokens = [self.initial_tokens] + self.tokens[2:]
+            logger.debug(f"fold tokens into context: {len(self.tokens)} entries, {total_tok_len} tokens")
+
         return removed_len
 
     def _clean_cache(self):

--- a/simulstreaming/whisper/whisper_streaming/whisper_server.py
+++ b/simulstreaming/whisper/whisper_streaming/whisper_server.py
@@ -59,15 +59,15 @@ class ServerProcessor:
         # - the first two words are:
         #    - beg and end timestamp of the text segment, as estimated by Whisper model. The timestamps are not accurate, but they're useful anyway
         # - the next words: segment transcript
-        if iteration_output:
-            if self.out_txt:
-                message = "%1.0f %1.0f %s" % (iteration_output['start'] * 1000, iteration_output['end'] * 1000, iteration_output['text'])
-            else:
-                message = json.dumps(iteration_output)
-            print(message, flush=True, file=sys.stderr)
-            self.connection.send(message)
-        else:
+        if not iteration_output or 'text' not in iteration_output:
             logger.debug("No text in this segment")
+            return
+        if self.out_txt:
+            message = "%1.0f %1.0f %s" % (iteration_output['start'] * 1000, iteration_output['end'] * 1000, iteration_output['text'])
+        else:
+            message = json.dumps(iteration_output)
+        print(message, flush=True, file=sys.stderr)
+        self.connection.send(message)
 
     def process(self):
         # handle one client connection


### PR DESCRIPTION
## Summary

- **Fix KeyError crash in `send_result()`**: When VAC is enabled, `VACOnlineASRProcessor.process_iter()` can return `{"is_final": False}` (empty transcription segment). This is truthy, so `send_result()` enters the formatting branch and crashes accessing `iteration_output['start']`. Fixed by checking for `'text'` key presence instead of just dict truthiness.

- **Bound unbounded `self.tokens` growth**: During long streaming sessions (8+ hours), `self.tokens` grows without limit because `infer()` appends new entries each call, but they are only trimmed when audio segments overflow `audio_max_len`. Added a loop in `insert_audio()` that folds old token entries into context when total token count exceeds `max_text_len // 2`, matching the existing per-segment trimming pattern. This prevents memory growth that can eventually exhaust system resources.

- **Reduce default `max_context_tokens`**: The default was `max_text_len` (448 for Whisper), letting context consume the entire token budget before trimming. Reduced to `max_text_len // 2` so context is trimmed more aggressively, leaving room for decoding. Explicitly setting `--max_context_tokens` still overrides this default.

## Test plan

- [ ] Verify server no longer crashes when VAC returns empty segments (previously reproducible by streaming audio with periods of silence)
- [ ] Run a long streaming session and monitor memory usage — `self.tokens` list should stay bounded
- [ ] Verify transcription quality is not degraded by the earlier context trimming


🤖 Generated with [Claude Code](https://claude.com/claude-code)