### PR TITLE
Handle multibyte characters correctly in process (fixes #31)

### DIFF
--- a/simulstreaming/whisper/whisper_streaming/whisper_server.py
+++ b/simulstreaming/whisper/whisper_streaming/whisper_server.py
@@ -61,7 +61,11 @@ class ServerProcessor:
         # - the next words: segment transcript
         if iteration_output:
             if self.out_txt:
-                message = "%1.0f %1.0f %s" % (iteration_output['start'] * 1000, iteration_output['end'] * 1000, iteration_output['text'])
+                if iteration_output.get('start'):
+                    message = "%1.0f %1.0f %s" % (iteration_output['start'] * 1000, iteration_output['end'] * 1000, iteration_output['text'])
+                else:
+                    logger.debug("No token in this segment")
+                    return
             else:
                 message = json.dumps(iteration_output)
             print(message, flush=True, file=sys.stderr)

--- a/simulstreaming_whisper.py
+++ b/simulstreaming_whisper.py
@@ -147,6 +147,7 @@ class SimulWhisperOnline(OnlineProcessorInterface):
         self.model.refresh_segment(complete=True)
 
         self.unicode_buffer = []  # hide incomplete unicode character for the next iteration
+        self.frame_buffer = 0
 
     def insert_audio_chunk(self, audio):
         self.audio_chunks.append(torch.from_numpy(audio))
@@ -162,9 +163,10 @@ class SimulWhisperOnline(OnlineProcessorInterface):
             split_words, split_tokens = generation["result"]["split_words"], generation["result"]["split_tokens"]
 
         frames = [p["most_attended_frames"][0] for p in pr]
-        if self.unicode_buffer != []:
-            a = [frames[0]] * len(self.unicode_buffer)
+        if frames and self.frame_buffer:
+            a = [frames[0]] * self.frame_buffer #Buffer generation["result"] if timestamp accuracy becomes problem
             frames = a + frames
+            self.frame_buffer = 0
             
         tokens = tokens.copy()
         ret = []
@@ -196,6 +198,7 @@ class SimulWhisperOnline(OnlineProcessorInterface):
         if tokens == []:
             return tokens #To preserve unicode_buffer
         tokens = self.unicode_buffer + tokens #Add previous buffered token
+        self.frame_buffer = len(self.unicode_buffer)
         self.unicode_buffer = []
         decoded_str_bytes = self.model.tokenizer.encoding.decode_bytes_batch(
                 [[t] for t in tokens] #Split bytes on token

--- a/simulstreaming_whisper.py
+++ b/simulstreaming_whisper.py
@@ -193,16 +193,26 @@ class SimulWhisperOnline(OnlineProcessorInterface):
         starts with '�'.
         This function hides the last incomplete unicode character and adds it in the next iteration.
         """
-        if self.unicode_buffer != []:
-            logger.debug(f"Hiding incomplete unicode character: {self.unicode_buffer}")
-            tokens = self.unicode_buffer + tokens
-            self.unicode_buffer = []  # clear the buffer after processing
-        chars, _ = self.model.tokenizer.split_tokens_on_unicode(tokens)
-        if len(chars) > 0 and chars[-1].endswith('�'):
-            self.unicode_buffer = tokens[-1:]  # keep the last incomplete unicode character
-            logger.debug(f"Hiding incomplete unicode character: {tokens[-1:]}")
-            return tokens[:-1]  # remove the last token, which is incomplete unicode character
-        return tokens
+        if tokens == []:
+            return tokens #To preserve unicode_buffer
+        tokens = self.unicode_buffer + tokens #Add previous buffered token
+        self.unicode_buffer = []
+        decoded_str_bytes = self.model.tokenizer.encoding.decode_bytes_batch(
+                [[t] for t in tokens] #Split bytes on token
+                )
+        decoded_str = bytearray().join(decoded_str_bytes).decode('utf-8', errors="replace")
+        if len(decoded_str) > 0 and decoded_str[-1].endswith('�'): #split by char won't work because multple tokens can end up with one �.
+            for i in range(len(tokens)-1, 0, -1):
+                decoded_str_piece = bytearray().join(decoded_str_bytes[:i]).decode('utf-8', errors="replace")
+                if not (len(decoded_str_piece) > 0 and decoded_str_piece[-1].endswith('�')):
+                    self.unicode_buffer = tokens[i:]
+                    logger.debug(f"Hiding incomplete unicode character at end: {self.unicode_buffer}")
+                    return tokens[:i]
+            logger.debug(f"Failed to split token, fallback to previous behaviour")
+            self.unicode_buffer = [tokens[-1]]
+            return tokens[:-1]
+        else:
+            return tokens
 
     def process_iter(self):
         if len(self.audio_chunks) == 0:


### PR DESCRIPTION
## Summary
This PR addresses issue #31 by checking raw bytes to prevent failures caused by multibyte (3-byte) characters.

### Background
In some cases, text containing 3-byte characters (e.g., Japanese) could be processed incorrectly and lead to an “index out of range” error.
These cases tend to include two consecutive illegal bytes, and 3-byte characters can easily trigger this situation.

### Commit 1
- `hide_incomplete_unicode` now uses `self.model.tokenizer.encoding.decode_bytes_batch` instead of `self.model.tokenizer.split_tokens_on_unicode`. Token decoding still occurs once per iteration.
- The replacement-character (`�`) check now runs per token, and all detected tokens are buffered.

### Commit 2
After Commit 1, I observed an increased frequency of `pop from empty list: frames.pop(0)` exceptions.  
I found that `timestamped_text` adds frames depending on the length of `self.unicode_buffer`. Previously, the untranslated part of `generation[result][frames]` often compensated for this, but the increased buffer size made the behavior unstable. This commit adds an additional fix:

- Introduced a new variable `frame_buffer` to record the length of `unicode_buffer` and pad/fill frames accordingly.

### Commit 3
`iteration_output` sometimes contains only `is_final` and `emission_time`, which caused a `KeyError`.
Example: `{"is_final": false, "emission_time": 57.90499949455261}`

- Added a guard to ensure `iteration_output` has at least the `start` key before accessing it.

### Result
With these fixes applied, SimulStreaming worked without issues during a 10-hour field test in a Japanese environment.

### References
- https://github.com/ufal/SimulStreaming/issues/31

#### P.S.
This is my first time using the “git” side of GitHub. If I made any mistakes in the PR, I’d appreciate any guidance.