### PR TITLE
Fix server crash on Windows when a client disconnects mid-stream (WinError 10053)

### DIFF
--- a/simulstreaming/utils/server_utils.py
+++ b/simulstreaming/utils/server_utils.py
@@ -25,5 +25,5 @@ class Connection:
         try:
             r = self.conn.recv(self.PACKET_SIZE)
             return r
-        except ConnectionResetError:
+        except (ConnectionResetError, ConnectionAbortedError):
             return None

--- a/simulstreaming/whisper/whisper_streaming/whisper_server.py
+++ b/simulstreaming/whisper/whisper_streaming/whisper_server.py
@@ -86,7 +86,7 @@ class ServerProcessor:
                 o["emission_time"] = time.time() - beg_time
             try:
                 self.send_result(o)
-            except BrokenPipeError:
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
                 logger.info("broken pipe -- connection closed?")
                 break
 


### PR DESCRIPTION
## Problem
On Windows, the transcription TCP server crashes (process exits 1) whenever a
client disconnects mid-session, e.g. the client closes its socket on a
listen-window timeout right as the server is about to emit a partial:

    ConnectionAbortedError: [WinError 10053] An established connection was
    aborted by the software in your host machine

## Root cause
The server only handles UNIX:
- `ServerProcessor.process()` wraps `send_result()` in `except BrokenPipeError`.
- `Connection.non_blocking_receive_audio()` catches `except ConnectionResetError`.

On Windows a client-initiated disconnect raises `ConnectionAbortedError (WinError 10053)`
on send (and can on recv). It escapes both handlers and kills the whole server process.
On Linux/macOS the same disconnect surfaces as BrokenPipeError, which is why this only bites on Windows.

## Fix
Broaden both handlers to also catch the Windows disconnect errors (see diff).

## Repro
1. Run `simulstreaming_whisper_server.py` on Windows with `--vac`.
2. Stream mic audio, then close the client mid-utterance (e.g. a short client
   receive timeout that fires just as the first partial is produced).
3. Before: crash, WinError 10053, exit 1. After: server logs the disconnect and
   serves the next connection.